### PR TITLE
Signal config, heartbeat, and errors with led

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ static nrf_clock_lf_cfg_t clock_lf_cfg = NRF_CLOCK_LFCLKSRC;
 /** @brief General error handler. */
 static inline void error_loop(void) {
   log("In error_loop");
-  TOGGLE_LED(LED_RED);
+  nrf_gpio_pin_clear(STATUS_LED_PIN); // Turn on status led
   __disable_irq();
   while (true) {
     power_manage();
@@ -166,13 +166,6 @@ int main(void) {
   log("Mesh control init");
   mesh_control_init();
 
-#if LEDS_NUMBER > 0
-  log("Some LEDs");
-  nrf_gpio_cfg_output(LED_START + LED_GREEN);
-  nrf_gpio_cfg_output(LED_START + LED_RED);
-  nrf_gpio_cfg_output(LED_START + LED_BLUE);
-#endif
-
   log("Enabling sd handler");
 /* Enable Softdevice (including sd_ble before framework */
 
@@ -246,6 +239,7 @@ int main(void) {
   /* Enable our handle */
   if (Config.GetSensorID() > 0) {
     logf("Sensor ID = %d", Config.GetSensorID());
+    nrf_gpio_pin_clear(STATUS_LED_PIN); // Turn on led if ID configured
     sensor_init();
   } else {
     log("WARNING: Sensor ID not set");

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -68,6 +68,7 @@ static void periodic_timer_cb(void * p_context)
     GET_APP_TIMER(m_clock_second_start_counter_value);
     m_scheduler_state = SCHEDULER_STATE_BEFORE_HB;
     rbc_mesh_start();
+    nrf_gpio_pin_clear(STATUS_LED_PIN);
 
     delay_to_heartbeat();
   }
@@ -132,6 +133,7 @@ static void offset_timer_cb(void * p_context) {
 
   switch (m_scheduler_state) {
     case SCHEDULER_STATE_BEFORE_HB:
+      nrf_gpio_pin_set(STATUS_LED_PIN); // Turn off status led
       do_heartbeat();
       m_scheduler_state = SCHEDULER_STATE_AFTER_HB;
       delay_to_reporting();


### PR DESCRIPTION
On power-up, if sensor has id configured, the led will light for 10s. This provides a way to see if the sensors is not configured for some reason.

During each heartbeat schedule, the led will blink for a very short fraction of time, which helps diagnose if sensor clocks are drifting, or if sensors are not participating in the mesh.

If a softdevice crash or hardware fault occur, the status led will turn on and stay on.