### PR TITLE
Adjust min/max voltage ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Program a master clock device that doesn't sleep, listens all the time, and broa
 `make program SERIAL_PORT=/dev/cu.usbserial-AI04QL7P SENSOR_CONFIGURATION_OPTIONS="--no-sleep" TARGET_BOARD=BOARD_LESSON_TRACKER CLOCK_MASTER=yes SENSOR_ID=61`
 
 # Debugging
-- `make install_nordic_full debug -j9 DEBUG=1 VERBOSE=1`
+- `make install_nordic_full debug -j9 DEBUG=1 VERBOSE=1 TARGET_BOARD=BOARD_SHOE_SENSORv2`
 - `JLinkGDBServer -if swd -device nrf52 -speed 4000`
 - `arm-none-eabi-gdb _build/*.elf`
   - `target remote :2331`

--- a/bsp/lesson_tracker_nrf52.h
+++ b/bsp/lesson_tracker_nrf52.h
@@ -19,14 +19,17 @@ extern "C" {
 #define BATTERY_SENSE_PIN NRF_SAADC_INPUT_AIN2
 #define BATTERY_SENSE_ADC_GAIN NRF_SAADC_GAIN1_6
 #define BATTERY_SENSE_ADC_RESOLUTION NRF_SAADC_RESOLUTION_12BIT
+// GAIN = 1/6
+// REFERENCE = 0.6V
 // ADC scale =  GAIN/REFERENCE * 2^(RESOLUTION)
 #define BATTERY_SENSE_ADC_SCALE ((1/6.0)/0.6*(1<<12))
 // Voltage divider.  R1 = 3.9 MOhm, R2 = 10 MOhm
 #define BATTERY_SENSE_EXTERNAL_SCALE (10.0 / (3.9 + 10.0))
-//#define BATTERY_SENSE_EXTERNAL_SCALE (1.0 / (1.0 + 1.0))
 
+// Max charge of lipo = 4.2V
 #define BATTERY_MAX_VOLTAGE 4.2
-#define BATTERY_MIN_VOLTAGE 2.7
+// Lipo protection circuit low voltage cut-off = 2.8V
+#define BATTERY_MIN_VOLTAGE 2.8
 
 // Disable BSP
 #define LEDS_NUMBER 0

--- a/bsp/lesson_tracker_nrf52.h
+++ b/bsp/lesson_tracker_nrf52.h
@@ -28,8 +28,9 @@ extern "C" {
 
 // Max charge of lipo = 4.2V
 #define BATTERY_MAX_VOLTAGE 4.2
-// Lipo protection circuit low voltage cut-off = 2.8V
-#define BATTERY_MIN_VOLTAGE 2.8
+// Lipo protection circuit low voltage cut-off = 2.8V,
+// but 3V will give less of a % cliff as end of battery nears.
+#define BATTERY_MIN_VOLTAGE 3.0
 
 // Disable BSP
 #define LEDS_NUMBER 0

--- a/bsp/shoe_sensor_nrf52.h
+++ b/bsp/shoe_sensor_nrf52.h
@@ -24,12 +24,16 @@ extern "C" {
 #define BATTERY_SENSE_PIN NRF_SAADC_INPUT_VDD
 #define BATTERY_SENSE_ADC_GAIN NRF_SAADC_GAIN1_5
 #define BATTERY_SENSE_ADC_RESOLUTION NRF_SAADC_RESOLUTION_12BIT
+// GAIN = 1/5
+// REFERENCE = 0.6V
 // ADC scale =  GAIN/REFERENCE * 2^(RESOLUTION)
 #define BATTERY_SENSE_ADC_SCALE ((1/5.0)/0.6*(1<<12))
 // No voltage divider
 #define BATTERY_SENSE_EXTERNAL_SCALE 1
 
-#define BATTERY_MAX_VOLTAGE 3.3
+// Coin cells seem to start at 2.72, when current is being used
+#define BATTERY_MAX_VOLTAGE 2.72
+// nrf51 can go to 1.7, but imu can only go to 2.4.
 #define BATTERY_MIN_VOLTAGE 2.1
 
 // Disable BSP

--- a/bsp/shoe_sensor_nrf52.h
+++ b/bsp/shoe_sensor_nrf52.h
@@ -32,8 +32,8 @@ extern "C" {
 #define BATTERY_SENSE_EXTERNAL_SCALE 1
 
 // Coin cells seem to start at 2.72, when current is being used
-#define BATTERY_MAX_VOLTAGE 2.72
-// nrf51 can go to 1.7, but imu can only go to 2.4.
+#define BATTERY_MAX_VOLTAGE 2.7
+// nrf52 can go to 1.7, but imu can only go to 2.4.
 #define BATTERY_MIN_VOLTAGE 2.1
 
 // Disable BSP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "mesh_control.h"
 #include "nrf_gpio.h"
 #include "nrf_delay.h"
+#include "nrf_drv_saadc.h"
 #include "power_manage.h"
 #include "rtc.h"
 #include "scheduler.h"
@@ -233,6 +234,8 @@ int main(void) {
   // Configure status LED
   nrf_gpio_cfg_output(STATUS_LED_PIN);
   nrf_gpio_pin_set(STATUS_LED_PIN); // Low = On, High = Off
+
+  nrf_drv_saadc_calibrate_offset();
 
   /* Initialize mesh ACI */
   mesh_aci_init();

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -43,6 +43,12 @@ void gather_sensor_data() {
   log("checking voltage");
   voltage = get_battery_voltage();
   // Convert to percent
+  if (voltage < BATTERY_MIN_VOLTAGE) {
+    voltage = BATTERY_MIN_VOLTAGE;
+  }
+  if (voltage > BATTERY_MAX_VOLTAGE) {
+    voltage = BATTERY_MAX_VOLTAGE;
+  }
   m_value.battery = (voltage - BATTERY_MIN_VOLTAGE) / (BATTERY_MAX_VOLTAGE - BATTERY_MIN_VOLTAGE) * 100;
   logf("battery percent = %d", m_value.battery);
 


### PR DESCRIPTION
 After testing adc and reviewing lipo protection circuit, and imu datasheet, the voltage ranges needed to be adjusted, so that percentages would more accurately indicate when action needed to be taken.